### PR TITLE
Update PyYaml Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord_webhook == 0.13.0
-pyyaml == 5.4.1
+pyyaml >= 6.0.1
 pre-commit == 2.13.0
 black == 21.5b1
 flake8 == 3.9.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", mode="r") as fd:
 
 setuptools.setup(
     name="discord-logger",
-    version="1.2.3",
+    version="1.2.4",
     author="Chaitanya Chinni",
     description="Discord Logger is a custom message logger to Discord for Python 3",
     license="MIT License",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/chinnichaitanya/python-discord-logger",
     packages=setuptools.find_packages(),
-    install_requires=["discord-webhook == 0.13.0", "pyyaml == 5.4.1"],
+    install_requires=["discord-webhook == 0.13.0", "pyyaml >= 6.0.1"],
     classifiers=[
         "Environment :: Web Environment",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Cython 3.0 was released. This breaks PyYaml 5.4.1 (a dependency of discord-logger). PyYaml<=5.4 has a bug which can lead to ACE ([https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14343)) set version to 6.0.1 because discord-logger depends on PyYaml >5.4, <6.0